### PR TITLE
Resolve CSRF origin verification failure

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -27,6 +27,10 @@ DEBUG = True
 
 ALLOWED_HOSTS = ["connect-indu.onrender.com","*"]
 
+# CSRF trusted origins for production
+CSRF_TRUSTED_ORIGINS = [
+    "https://connect-indu.onrender.com",
+]
 
 # Application definition
 


### PR DESCRIPTION
Add `CSRF_TRUSTED_ORIGINS` to allow Django app to accept requests from Render deployment.

This resolves the 'CSRF verification failed' error where `https://connect-indu.onrender.com` was not recognized as a trusted origin by Django's CSRF middleware.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-2dd4b30c-9040-4708-8fcb-74a8376bc42d) · [Cursor](https://cursor.com/background-agent?bcId=bc-2dd4b30c-9040-4708-8fcb-74a8376bc42d)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)